### PR TITLE
Update Setup PHP to version 2 and update Prestissimo installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,11 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, zip
+        tools: prestissimo
         coverage: pcov
 
     - name: Install Composer dependencies
-      run: |
-        composer global require hirak/prestissimo
-        composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
 
     - name: PHPStan Analysis
       run: vendor/bin/phpstan analyse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, zip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the Setup PHP GitHub Action to version 2, and moves Prestissimo installation to the Tools config instead of a separate command.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
