### PR TITLE
Update future projects to be Treeware

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ Read more about Treeware at [treeware.earth][link-treeware].
 [link-code-coverage]: https://codecov.io/gh/owenvoke/:package_name
 [link-downloads]: https://packagist.org/packages/owenvoke/:package_name
 [link-treeware]: https://treeware.earth
-[link-treeware-gifting]: https://offset.earth/treeware?gift-trees
+[link-treeware-gifting]: https://offset.earth/owenvoke?gift-trees
 [link-author]: https://github.com/owenvoke
 [link-contributors]: ../../contributors

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Style CI][ico-styleci]][link-styleci]
 [![Code Coverage][ico-code-coverage]][link-code-coverage]
 [![Total Downloads][ico-downloads]][link-downloads]
+[![Buy us a tree][ico-treeware-gifting]][link-treeware-gifting]
 
 :package_description
 
@@ -48,17 +49,30 @@ If you discover any security related issues, please email security@voke.dev inst
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
 
+## Treeware
+
+You're free to use this package, but if it makes it to your production environment you are required to buy the world a tree.
+
+It’s now common knowledge that one of the best tools to tackle the climate crisis and keep our temperatures from rising above 1.5C is to plant trees. If you support this package and contribute to the Treeware forest you’ll be creating employment for local families and restoring wildlife habitats.
+
+You can buy trees [here][link-treeware-gifting].
+
+Read more about Treeware at [treeware.earth][link-treeware].
+
 [ico-version]: https://img.shields.io/packagist/v/owenvoke/:package_name.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 [ico-github-actions]: https://img.shields.io/github/workflow/status/owenvoke/:package_name/Continuous%20Integration.svg?style=flat-square
 [ico-styleci]: https://styleci.io/repos/:styleci/shield
 [ico-code-coverage]: https://img.shields.io/codecov/c/github/owenvoke/:package_name.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/owenvoke/:package_name.svg?style=flat-square
+[ico-treeware-gifting]: https://img.shields.io/badge/Treeware-%F0%9F%8C%B3-lightgreen?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/owenvoke/:package_name
 [link-github-actions]: https://github.com/owenvoke/:package_name/actions
 [link-styleci]: https://styleci.io/repos/:styleci
 [link-code-coverage]: https://codecov.io/gh/owenvoke/:package_name
 [link-downloads]: https://packagist.org/packages/owenvoke/:package_name
+[link-treeware]: https://treeware.earth
+[link-treeware-gifting]: https://offset.earth/treeware?gift-trees
 [link-author]: https://github.com/owenvoke
 [link-contributors]: ../../contributors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This updates all future packages to be [Treeware](https://treeware.earth) by default.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.