### PR TITLE
Remove "--no-suggest" flag for Composer update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         coverage: pcov
 
     - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
     - name: PHPStan Analysis
       run: vendor/bin/phpstan analyse


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This prepares the installation for Composer v2 which removes the
"--no-suggest" flag from  the update command.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
