### PR TITLE
Add additional PHPStan rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "require-dev": {
         "pestphp/pest": "^0.2",
         "phpstan/phpstan": "^0.12.31",
-        "symfony/var-dumper": "^5.1"
+        "symfony/var-dumper": "^5.1",
+        "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "require-dev": {
         "pestphp/pest": "^0.2",
         "phpstan/phpstan": "^0.12.31",
+        "phpstan/phpstan-strict-rules": "^0.12.2",
         "symfony/var-dumper": "^5.1",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": "^7.4"
     },
     "require-dev": {
+        "ergebnis/phpstan-rules": "^0.15.0",
         "pestphp/pest": "^0.2",
         "phpstan/phpstan": "^0.12.31",
         "phpstan/phpstan-strict-rules": "^0.12.2",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,8 @@
+includes:
+  - vendor/phpstan/phpstan-strict-rules/rules.neon
+  - vendor/ergebnis/phpstan-rules/rules.neon
+  - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+
 parameters:
   level: 8
   paths:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

One thing I want to decide is whether to add a meta-package that installs all of these. Similar to [`pest-dev-tools`](https://github.com/pestphp/pest-dev-tools).

This would include:
- Rector
- Pest
- PHPStan (and rulesets)
- Symfony Var Dumper

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/skeleton-php/blob/master/.github/CONTRIBUTING.md)** document.
