### PR TITLE
ci: update structure of workflows

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,30 @@
+name: Static Analysis
+
+on: ['push', 'pull_request']
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dependency-version: [prefer-lowest, prefer-stable]
+
+    name: PHPStan (${{ matrix.dependency-version }})
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+        tools: composer:v2
+        coverage: none
+
+    - name: Install Dependencies
+      run: composer update --prefer-stable --no-interaction --prefer-dist
+
+    - name: Run PHPStan
+      run: vendor/bin/phpstan analyse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,18 @@
-name: CI
+name: Tests
 
 on: ['push', 'pull_request']
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
       matrix:
+        os: [ubuntu-latest]
         php: [7.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
-    name: CI - PHP ${{ matrix.php }} (${{ matrix.dependency-version }})
+    name: PHP ${{ matrix.php }} (${{ matrix.dependency-version }})
 
     steps:
 
@@ -23,15 +23,16 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: mbstring, zip
         tools: composer:v2
         coverage: none
+
+    - name: Setup Problem Matchers
+      run: |
+        echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install Composer dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
-    - name: Type Checks
-      run: vendor/bin/phpstan analyse
-
-    - name: Unit Tests
+    - name: Run Unit Tests
       run: vendor/bin/pest --colors=always

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Read more about Treeware at [treeware.earth][link-treeware].
 
 [ico-version]: https://img.shields.io/packagist/v/owenvoke/skeleton-php.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-github-actions]: https://img.shields.io/github/workflow/status/owenvoke/skeleton-php/CI.svg?style=flat-square
+[ico-github-actions]: https://img.shields.io/github/workflow/status/owenvoke/skeleton-php/Tests.svg?style=flat-square
 [ico-styleci]: https://styleci.io/repos/:styleci/shield
 [ico-downloads]: https://img.shields.io/packagist/dt/owenvoke/skeleton-php.svg?style=flat-square
 [ico-treeware-gifting]: https://img.shields.io/badge/Treeware-%F0%9F%8C%B3-lightgreen?style=flat-square


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This updates the CI into 2 separate workflows. One for Tests, and one for Static Analysis. The steps are also renamed to be clearer.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/skeleton-php/blob/master/.github/CONTRIBUTING.md)** document.
