### PR TITLE
ci: add ansi flag to output

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,10 +20,10 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --no-interaction --prefer-dist --no-progress
+      run: composer update --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run Rector
-      run: vendor/bin/rector process src --dry-run
+      run: vendor/bin/rector process src --dry-run --ansi
 
   phpstan:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --prefer-stable --no-interaction --prefer-dist --no-progress
+      run: composer update --prefer-stable --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run PHPStan
-      run: vendor/bin/phpstan analyse --no-progress
+      run: vendor/bin/phpstan analyse --no-progress --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,11 +30,11 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP 7 dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
       if: "matrix.php < 8"
 
     - name: Install PHP 8 dependencies
-      run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+      run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress --ansi
       if: "matrix.php >= 8"
 
     - name: Unit Tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Waiting on a new release (assuming `v0.8.15`) of Rector that includes rectorphp/rector@251789c82c04c325ef1468b8e563d67db6ce90bb

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/skeleton-php/blob/main/.github/CONTRIBUTING.md)** document.
